### PR TITLE
Suggested changes to simplify for coveralls github action

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,5 +21,6 @@ jobs:
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:
+          path-to-lcov: ./coverage.lcov
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: coverage report

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,8 +17,7 @@ jobs:
       - run: pip install numpy
       - run: pip install -U pytest coverage coveralls PyYAML
       - run: coverage run -m --source=. pytest
-      - run: coveralls --output=coverage.json
-      - run: coveralls-lcov -v -n coverage.info > coverage.json
+      - run: coverage lcov
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install numpy
-      - run: pip install -U pytest coverage coveralls PyYAML
+      - run: pip install -U pytest coverage
       - run: coverage run -m --source=. pytest
       - run: coverage lcov
       - name: Coveralls GitHub Action


### PR DESCRIPTION
First, here is an advanced usage of github, where I am making a PR into your branch.  If you accept this PR, it will update your branch and update your PR, but retain line-by-line authorship credit.

This makes a few changes:
1. uses `coverage.py` to generate an LCOV file
2. tells the github action where to find that LCOV file
3. removes the explicit installation of coveralls and PyYAML since they are handled by the action
